### PR TITLE
 f7 docker compose operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,41 @@
-Readme for Operation
+# Operation: Run the App + Model Service with Docker Compose
+
+This repository provides a simple docker compose setup to run the two services used in the project:
+
+
+**Quick start**
+
+1. Make sure Docker is running on your machine.
+2. From this repository root run:
+
+```bash
+docker compose up -d
+```
+
+3. Open your browser at `http://localhost:8080` to access the `app` frontend.
+
+To stop the services:
+
+```bash
+docker compose down
+```
+
+**Rebuilding / developing locally**
+
+If you need to build the images locally (for development or after changes), build and tag the images and then restart the compose stack.
+
+Example (build locally and run):
+
+```bash
+# build app image
+cd app
+docker build -t ghcr.io/doda25-team2/app:latest .
+
+# build model-service image
+cd ../model-service
+docker build -t ghcr.io/doda25-team2/model-service:latest .
+
+# go back to repo root and start compose 
+cd ../operation
+docker compose up -d --build
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+services:
+  model-service:
+    image: ghcr.io/doda25-team2/model-service:latest
+    environment:
+      - MODEL_SERVICE_PORT=8081
+    volumes:
+      - model-data:/models
+    restart: unless-stopped
+
+  app:
+    image: ghcr.io/doda25-team2/app:latest
+    depends_on:
+      - model-service
+    ports:
+      - "8080:8080"
+    environment:
+      - APP_PORT=8080
+      - MODEL_SERVICE_URL=http://model-service:8081
+    restart: unless-stopped
+
+volumes:
+  model-data:


### PR DESCRIPTION
This PR adds the required Docker Compose setup for running the full application (app + model-service) as part of F7.

added features:

-docker-compose.yml defining app service and model service

-Environment variables wired to the behavior implemented in F6 (APP_PORT, MODEL_SERVICE_URL, MODEL_SERVICE_PORT)

-A short README.md explaining how to run the stack

How to Test
1. Build images locally (temporary until GHCR images exist)
docker build -t ghcr.io/doda25-team2/app:latest ../app
docker build -t ghcr.io/doda25-team2/model-service:latest ../model-service

2. Start the full stack
docker compose up

(Need to further test with other docker requirements from the assignment once all is done)
