### PR TITLE
implemented step 7 and 8

### DIFF
--- a/general.yaml
+++ b/general.yaml
@@ -70,6 +70,7 @@
         value: '1'
         state: present
         reload: yes
+        sysctl_set: yes
 
     - name: Enable bridged iptables
       ansible.builtin.sysctl:
@@ -77,6 +78,7 @@
         value: '1'
         state: present
         reload: yes
+        sysctl_set: yes
 
     - name: Enable bridged ip6tables
       ansible.builtin.sysctl:
@@ -84,6 +86,7 @@
         value: '1'
         state: present
         reload: yes
+        sysctl_set: yes
 
     - name: Render hosts template
       ansible.builtin.template:


### PR DESCRIPTION
Step 7: Enabled kernel property " net.ipv4.ip_forward" for cluster nodes. Also implemented for the bridge iptable and ip6tables.

ansible.builtin.sysctl was used in which state: present and  sysctl_set: yes was also added in which state: present is for the sysctl key to be present in the config and the sysctl_set: yes uses the value when running. 

Step 8: etc/hosts is managed through using the blockinfile module rather then the copy since the blockinfile module  is idempotent as it inserts/updates the specific block added. A marker is added to make it easier to know. Backup is set to yes if there is some issue when running it but can be removed later when we know it works 100%.  The "block" is added and is important since this is where the jinja loop is added. 

