### PR TITLE
Cleanup Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,6 +13,17 @@ Vagrant.configure("2") do |config|
   config.vm.box = VAGRANT_BOX
   config.vm.synced_folder ".", "/vagrant"
 
+  config.vm.provision "ansible_local" do |ansible|
+    ansible.install = true
+    ansible.become  = true
+    ansible.playbook = "/vagrant/general.yaml"
+    ansible.extra_vars = {
+      worker_count: WORKER_COUNT,
+      ctrl_ip: CTRL_IP,
+      worker_ip_base: WORKER_IP_BASE
+    }
+  end
+
   config.vm.define "ctrl" do |node|
     node.vm.hostname = "ctrl"
     node.vm.network "private_network", ip: CTRL_IP
@@ -24,22 +35,11 @@ Vagrant.configure("2") do |config|
     end
 
     node.vm.provision "ansible_local" do |ansible|
-      ansible.install = true
-      ansible.become  = true
-      ansible.playbook = "/vagrant/general.yaml"
+      ansible.playbook = "/vagrant/ctrl.yaml"
       ansible.extra_vars = {
         worker_count: WORKER_COUNT,
         ctrl_ip: CTRL_IP,
         worker_ip_base: WORKER_IP_BASE
-      }
-    end
-
-    node.vm.provision "ansible_local" do |ansible|
-      ansible.install = true
-      ansible.become  = true
-      ansible.playbook = "/vagrant/ctrl.yaml"
-      ansible.extra_vars = {
-        ctrl_ip: CTRL_IP
       }
     end
   end
@@ -57,22 +57,11 @@ Vagrant.configure("2") do |config|
       end
 
       node.vm.provision "ansible_local" do |ansible|
-        ansible.install = true
-        ansible.become  = true
-        ansible.playbook = "/vagrant/general.yaml"
+        ansible.playbook = "/vagrant/node.yaml"
         ansible.extra_vars = {
           worker_count: WORKER_COUNT,
           ctrl_ip: CTRL_IP,
           worker_ip_base: WORKER_IP_BASE
-        }
-      end
-
-      node.vm.provision "ansible_local" do |ansible|
-        ansible.install = true
-        ansible.become  = true
-        ansible.playbook = "/vagrant/node.yaml"
-        ansible.extra_vars = {
-          ctrl_ip: CTRL_IP
         }
       end
     end


### PR DESCRIPTION
A mild refactor to the `Vagrantfile` that removes redundancies in code. 

## How

 Run the `general.yaml` on all the nodes first, then apply the `ctrl` and `node-*` playbooks to individual VMs.

