### PR TITLE
Fix nodes not being able to SSH into ctrl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ admin.conf
 
 # Temporary files
 tmp*
+ctrl_id_ed25519*

--- a/ctrl.yaml
+++ b/ctrl.yaml
@@ -68,3 +68,30 @@
       args:
         executable: /bin/bash
       when: not kubeinit.stat.exists
+
+    - name: Generate SSH key for vagrant user
+      become_user: vagrant
+      command: ssh-keygen -t ed25519 -N "" -f /home/vagrant/.ssh/id_ed25519
+      args:
+        creates: /home/vagrant/.ssh/id_ed25519
+
+    - name: Add ctrl's own public key to authorized_keys
+      become_user: vagrant
+      ansible.posix.authorized_key:
+        user: vagrant
+        state: present
+        key: "{{ lookup('file', '/home/vagrant/.ssh/id_ed25519.pub') }}"
+
+    - name: Copy ctrl private key to shared folder
+      copy:
+        remote_src: yes
+        src: /home/vagrant/.ssh/id_ed25519
+        dest: /vagrant/ctrl_id_ed25519
+        mode: '0600'
+
+    - name: Copy ctrl public key to shared folder
+      copy:
+        remote_src: yes
+        src: /home/vagrant/.ssh/id_ed25519.pub
+        dest: /vagrant/ctrl_id_ed25519.pub
+        mode: '0644'

--- a/node.yaml
+++ b/node.yaml
@@ -8,6 +8,33 @@
         path: /etc/kubernetes/kubelet.conf
       register: kubelet_conf
 
+    - name: Wait for ctrl SSH keys to be available
+      wait_for:
+        path: "{{ item }}"
+        timeout: 300
+      loop:
+        - /vagrant/ctrl_id_ed25519
+        - /vagrant/ctrl_id_ed25519.pub
+      when: not kubelet_conf.stat.exists
+
+    - name: Copy ctrl's private key to node
+      copy:
+        src: /vagrant/ctrl_id_ed25519
+        dest: /home/vagrant/.ssh/id_ed25519
+        owner: vagrant
+        group: vagrant
+        mode: '0600'
+      when: not kubelet_conf.stat.exists
+
+    - name: Copy ctrl's public key to node
+      copy:
+        src: /vagrant/ctrl_id_ed25519.pub
+        dest: /home/vagrant/.ssh/id_ed25519.pub
+        owner: vagrant
+        group: vagrant
+        mode: '0644'
+      when: not kubelet_conf.stat.exists
+
     - name: Wait for ctrl SSH to be ready
       wait_for:
         host: "{{ ctrl_ip }}"
@@ -15,8 +42,16 @@
         timeout: 300
       when: not kubelet_conf.stat.exists
 
+    - name: Add ctrl to known_hosts
+      become_user: vagrant
+      shell: ssh-keyscan -H {{ ctrl_ip }} >> /home/vagrant/.ssh/known_hosts
+      args:
+        creates: /home/vagrant/.ssh/known_hosts
+      when: not kubelet_conf.stat.exists
+
     - name: Test SSH connection to ctrl
-      command: ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 vagrant@{{ ctrl_ip }} echo "connected"
+      become_user: vagrant
+      command: ssh -i /home/vagrant/.ssh/id_ed25519 -o ConnectTimeout=10 vagrant@{{ ctrl_ip }} echo "connected"
       register: ssh_test
       changed_when: false
       failed_when: false
@@ -28,7 +63,8 @@
       when: not kubelet_conf.stat.exists
 
     - name: Generate join command on controller
-      shell: ssh -o StrictHostKeyChecking=no vagrant@{{ ctrl_ip }} "sudo kubeadm token create --print-join-command"
+      become_user: vagrant
+      shell: ssh -i /home/vagrant/.ssh/id_ed25519 vagrant@{{ ctrl_ip }} "sudo kubeadm token create --print-join-command"
       register: join_cmd
       when: 
         - not kubelet_conf.stat.exists


### PR DESCRIPTION
The `Debug SSH test result` task for both `node-1` and `node-2` was failing with the following lines:
```
Permission denied, please try again.
Permission denied, please try again.
vagrant@192.168.56.100: Permission denied (publickey,password).
```

In this PR, we now create a new SSH key pair, add it to the `authorized_keys` of `ctrl` and use the private key for the nodes.