### PR TITLE
Add ConfigMap, Secret, and Shared Storage

### DIFF
--- a/deployment/templates/app-deployment.yaml
+++ b/deployment/templates/app-deployment.yaml
@@ -55,6 +55,31 @@ spec:
               value: "8080"
             - name: MODEL_SERVICE_URL
               value: "http://model-service:8081"
+
+            # Values from ConfigMap
+            - name: APP_ENV
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "deployment.fullname" . }}-config
+                  key: APP_ENV
+            - name: APP_FEATURE_FLAG
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "deployment.fullname" . }}-config
+                  key: APP_FEATURE_FLAG
+
+            # Values from Secret
+            - name: SMTP_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "deployment.fullname" . }}-secret
+                  key: smtpUsername
+            - name: SMTP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "deployment.fullname" . }}-secret
+                  key: smtpPassword
+
           {{- with .Values.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}
@@ -65,6 +90,10 @@ spec:
           {{- end }}
           {{- with .Values.resources }}
           resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
       {{- with .Values.volumes }}

--- a/deployment/templates/configmap.yaml
+++ b/deployment/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "deployment.fullname" . }}-config
+  labels:
+    {{- include "deployment.labels" . | nindent 4 }}
+data:
+  APP_ENV: {{ .Values.appConfig.env | quote }}
+  APP_FEATURE_FLAG: {{ .Values.appConfig.featureFlag | quote }}

--- a/deployment/templates/secret.yaml
+++ b/deployment/templates/secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "deployment.fullname" . }}-secret
+  labels:
+    {{- include "deployment.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  smtpUsername: {{ .Values.smtp.username | quote }}
+  smtpPassword: {{ .Values.smtp.password | quote }}

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -159,17 +159,35 @@ autoscaling:
   # targetMemoryUtilizationPercentage: 80
 
 # Additional volumes on the output Deployment definition.
-volumes: []
-# - name: foo
-#   secret:
-#     secretName: mysecret
-#     optional: false
+volumes:
+  - name: shared-storage
+    hostPath:
+      path: /mnt/shared
+      type: DirectoryOrCreate
 
 # Additional volumeMounts on the output Deployment definition.
-volumeMounts: []
-# - name: foo
-#   mountPath: "/etc/foo"
-#   readOnly: true
+volumeMounts:
+  - name: shared-storage
+    mountPath: /mnt/shared
+    readOnly: false
+
+
+# Application config that will go into a ConfigMap
+appConfig:
+  env: "production"
+  featureFlag: "off"
+
+# SMTP (or similar) credentials that will go into a Secret.
+# These are just placeholders, real values should be provided via --set or a separate values file.
+smtp:
+  username: "CHANGE_ME_USERNAME"
+  password: "CHANGE_ME_PASSWORD"
+
+# Shared storage settings (for hostPath /mnt/shared)
+sharedStorage:
+  enabled: true
+  hostPath: /mnt/shared
+  mountPath: /mnt/shared
 
 nodeSelector: {}
 


### PR DESCRIPTION
his PR implements Issue 3 by extending the Helm chart with application configuration and shared storage support. A ConfigMap, Secret, and hostPath volume are now included in the app Deployment.

**What’s included**

- ConfigMap containing `APP_ENV` and `APP_FEATURE_FLAG`
- Secret containing placeholder S`MTP_USERNAME` and `SMTP_PASSWORD`
- Shared hostPath volume mounted at `/mnt/shared`

All values are managed via values.yaml.

**Deploy**: `helm upgrade --install operation ./deployment/`

**How to verify**
 `kubectl get pods`
`kubectl exec -it <app-pod-name> -- printenv | grep -E "APP_ENV|APP_FEATURE_FLAG|SMTP" `
```
kubectl exec -it <app-pod-name> -- ls -l /mnt/shared  
kubectl describe pod <app-pod-name> | grep -A5 "Mounts" 
```