### PR TITLE
Add Istio to Playbook

### DIFF
--- a/ansible/finalization.yaml
+++ b/ansible/finalization.yaml
@@ -1,8 +1,8 @@
 ---
 
-# ansible-playbook -u vagrant -i 192.168.56.100, ./ansible/finalization.yml
+# ansible-playbook -u vagrant -i 192.168.56.100, ./ansible/finalization.yaml
 # or if using WSL:
-# ansible-playbook -i ./ansible/inventory-wsl.ini ./ansible/finalization.yml
+# ansible-playbook -i ./ansible/inventory-wsl.ini ./ansible/finalization.yaml
 
 - hosts: all
   become: yes
@@ -231,3 +231,5 @@
     - name: Install Istio addons - kiali
       command: kubectl apply -f https://raw.githubusercontent.com/istio/istio/{{ istio_version }}/samples/addons/kiali.yaml
 
+    - name: Enable istio
+      command: kubectl label ns default istio-injection=enabled


### PR DESCRIPTION
## What this PR Does

This humble PR adds `istio` installation plays to the `finalization.yaml` playbook.

## Verification

1. Spin up the nodes (`vagrant up).
2. Run the `finalization.yaml`: 
```bash
# from .../operations
ansible-playbook -u vagrant -i 192.168.56.100, ./ansible/finalization.yaml
# or on WSL:
# ansible-playbook -i ./ansible/inventory-wsl.ini ./ansible/finalization.yaml
```
5.  SSH into a Vagrant node: `vagrant ssh ctrl`) 
6. Call `kubectl get pods -A`.

You should see the `istio-system` pods.

--- 

This PR only deals with Steps 1 and 2 of the _In-Class: Continuous Experimentation_ exercise that A4 introduces in Step 1:

> Traﬃc Management: The in-class exercise has walked you through the necessary steps to configure Istio for a
canary release. Adopt this example in your project as well. Your solution must show that you can deploy with Istio
and that you can use a Gateway and Virtual Services to make your web app accessible through an IngressGateway.
Replicate the in-class example and use DestinationRules for a canary release to a small fraction of the users.