### PR TITLE
Fix deadlock when installing deployment Helm chart

### DIFF
--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -236,3 +236,8 @@ kube-prometheus-stack:
           webhook_configs:
             - url: 'http://localhost:5001/webhook'
               send_resolved: true
+  prometheusOperator:
+    admissionWebhooks:
+      patch:
+        podAnnotations:
+          sidecar.istio.io/inject: "false"


### PR DESCRIPTION
Claude's explaination:

1. **The Job had 3 containers**: `istio-init`, `create`, and `istio-proxy` - indicating Istio sidecar injection was active
2. **The `create` container completed successfully** (Exit Code: 0, State: Terminated, Reason: Completed)
3. **But the pod status was "NotReady"** with `Ready: False` and `ContainersReady: False`
4. **The `istio-proxy` sidecar was still running** (State: Running, Ready: True)

This is a classic problem with Istio and Kubernetes Jobs. Jobs are meant to run to completion and exit, but Istio sidecars run indefinitely. When the main container finishes, the sidecar keeps running, preventing the Job from completing. Kubernetes waits for *all* containers in a pod to finish before marking a Job as complete.

The `helm install` command was hanging at the "Watching for changes to Job" step because it was waiting for the Job to complete, which would never happen with the sidecar still running.

The solution is to disable sidecar injection for these short-lived workloads using the `sidecar.istio.io/inject: "false"` annotation. This is a well-known pattern when using Istio with Jobs, init Jobs, or any other short-lived workload.