### PR TITLE
Add shared VirtualBox folder mount to /mnt/shared

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,18 +2,25 @@ VAGRANT_BOX         = "bento/ubuntu-24.04"
 VAGRANT_BOX_VERSION = "202510.26.0"
 CTRL_IP             = "192.168.56.100"
 WORKER_IP_BASE      = "192.168.56."
-WORKER_COUNT        = 2      
+WORKER_COUNT        = 2
 
 CTRL_CPUS           = 2
-CTRL_MEMORY_MB      = 4096     
+CTRL_MEMORY_MB      = 4096
 
 WORKER_CPUS         = 2
-WORKER_MEMORY_MB    = 6144      
+WORKER_MEMORY_MB    = 6144
+
+# Shared storage for Kubernetes hostPath volumes
+SHARED_FOLDER       = "./shared"      
 
 Vagrant.configure("2") do |config|
   config.vm.box = VAGRANT_BOX
   config.vm.box_version = VAGRANT_BOX_VERSION
   config.vm.synced_folder ".", "/vagrant"
+
+  # Shared folder for cross-VM and cross-Pod persistent storage
+  # This enables Kubernetes hostPath volumes to share data across all nodes
+  config.vm.synced_folder SHARED_FOLDER, "/mnt/shared", create: true
 
   config.vm.provision "ansible" do |ansible|
     ansible.playbook = "./ansible/general.yaml"


### PR DESCRIPTION
## What Changed

I added a shared VirtualBox folder to the Vagrantfile so that all cluster VMs mount the same directory. The local `./shared` folder is now mounted at `/mnt/shared` on every VM, which makes it easy to share data across nodes using Kubernetes `hostPath` volumes.

## Why

I believe this is required in order to obtain the excellent marks from **Assignment's 3** rubric.  It specifies that all VMs must mount the shame shared VirtualBox folder at `/mnt/shared`.

## Testing

After merging, you can verify everything is working with the following steps:

1. Bring up the cluster (if it’s not already running):

   ```
   vagrant up
   ```

2. Confirm the shared folder exists on each VM:

   ```
   vagrant ssh ctrl   -c 'ls -ld /mnt/shared'
   vagrant ssh node-1 -c 'ls -ld /mnt/shared'
   vagrant ssh node-2 -c 'ls -ld /mnt/shared'
   ```

3. Make sure data written on one VM is visible on another:

   ```
   vagrant ssh ctrl   -c 'echo "test" > /mnt/shared/test.txt'
   vagrant ssh node-1 -c 'cat /mnt/shared/test.txt'
   ```

If everything is set up correctly, all VMs should see the same contents under `/mnt/shared`.
