### PR TITLE
Add environment variable support to docker-compose.yml

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Docker Compose Environment Variables
+# Copy to .env and customize as needed
+
+MODEL_SERVICE_IMAGE=ghcr.io/doda25-team2/model-service:latest
+APP_IMAGE=ghcr.io/doda25-team2/app:latest
+MODEL_SERVICE_PORT=8081
+APP_HOST_PORT=8080

--- a/README.md
+++ b/README.md
@@ -20,6 +20,21 @@ To stop the services:
 docker compose down
 ```
 
+**Customizing image versions**
+
+You can override image versions and ports using environment variables. Copy `.env.example` to `.env` and customize:
+
+```bash
+cp .env.example .env
+# Edit .env to set custom image versions
+docker compose up -d
+```
+
+Or set them directly:
+```bash
+MODEL_SERVICE_IMAGE=ghcr.io/doda25-team2/model-service:v1.0.0 docker compose up -d
+```
+
 **Rebuilding / developing locally**
 
 If you need to build the images locally (for development or after changes), build and tag the images and then restart the compose stack.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,21 +1,21 @@
 services:
   model-service:
-    image: ghcr.io/doda25-team2/model-service:latest
+    image: ${MODEL_SERVICE_IMAGE:-ghcr.io/doda25-team2/model-service:latest}
     environment:
-      - MODEL_SERVICE_PORT=8081
+      - MODEL_SERVICE_PORT=${MODEL_SERVICE_PORT:-8081}
     volumes:
       - model-data:/models
     restart: unless-stopped
 
   app:
-    image: ghcr.io/doda25-team2/app:latest
+    image: ${APP_IMAGE:-ghcr.io/doda25-team2/app:latest}
     depends_on:
       - model-service
     ports:
-      - "8080:8080"
+      - "${APP_HOST_PORT:-8080}:8080"
     environment:
       - APP_PORT=8080
-      - MODEL_SERVICE_URL=http://model-service:8081
+      - MODEL_SERVICE_URL=http://model-service:${MODEL_SERVICE_PORT:-8081}
     restart: unless-stopped
 
 volumes:


### PR DESCRIPTION
## What Changed

I updated `docker-compose.yml` to support configuration through environment variables, with sensible defaults so it works out of the box. I also added a `.env.example` file to act as a template & document the available options and updated the README with instructions on how to customize image versions and port mappings.

## Why

This is done to meet the excellent rubric for **Assignment 1**, since the deployment must use an env file to configure things such as image names and versions.

## What Can Be Configured

The following settings can now be customized:

* `MODEL_SERVICE_IMAGE` – Container image for the model service
  *(default: `ghcr.io/doda25-team2/model-service:latest`)*
* `APP_IMAGE` – Container image for the app
  *(default: `ghcr.io/doda25-team2/app:latest`)*
* `MODEL_SERVICE_PORT` – Port used by the model service
  *(default: `8081`)*
* `APP_HOST_PORT` – Host port mapped to the app container
  *(default: `8080`)*

## Testing

You can verify the changes with these checks:

1. Confirm it works with defaults (no `.env` file required):

   ```
   docker compose config
   ```

2. Test overriding values via environment variables:

   ```
   MODEL_SERVICE_IMAGE=ghcr.io/doda25-team2/model-service:v1.0.0 docker compose config
   ```

3. Test using a `.env` file:

   ```
   cp .env.example .env
   # Edit .env to change versions
   docker compose config
   ```

In all cases, the output should reflect the correct image versions and configuration values.
