### PR TITLE
Added finalization playbook into vagrant provision

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -51,11 +51,21 @@ Vagrant.configure("2") do |config|
     node.vm.provision "ansible" do |ansible|
       ansible.playbook = "./ansible/ctrl.yaml"
       ansible.extra_vars = {
+        ctrl_ip: CTRL_IP
+      }
+    end
+
+    node.vm.provision "ansible" do |ansible|
+      ansible.playbook = "./ansible/finalization.yaml"
+      ansible.extra_vars = {
         ctrl_ip: CTRL_IP,
+        worker_count: WORKER_COUNT,
+        worker_ip_base: WORKER_IP_BASE
       }
     end
   end
 
+  # Worker nodes
   (1..WORKER_COUNT).each do |i|
     config.vm.define "node-#{i}" do |node|
       node.vm.hostname = "node-#{i}"
@@ -71,7 +81,7 @@ Vagrant.configure("2") do |config|
       node.vm.provision "ansible" do |ansible|
         ansible.playbook = "./ansible/node.yaml"
         ansible.extra_vars = {
-          ctrl_hostname: "ctrl",
+          ctrl_hostname: "ctrl"
         }
       end
     end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -54,15 +54,6 @@ Vagrant.configure("2") do |config|
         ctrl_ip: CTRL_IP
       }
     end
-
-    node.vm.provision "ansible" do |ansible|
-      ansible.playbook = "./ansible/finalization.yaml"
-      ansible.extra_vars = {
-        ctrl_ip: CTRL_IP,
-        worker_count: WORKER_COUNT,
-        worker_ip_base: WORKER_IP_BASE
-      }
-    end
   end
 
   # Worker nodes
@@ -83,6 +74,20 @@ Vagrant.configure("2") do |config|
         ansible.extra_vars = {
           ctrl_hostname: "ctrl"
         }
+      end
+
+      # Run finalization only after the last worker node is provisioned
+      # Target the ctrl node from node-2 to ensure all nodes are up
+      if i == WORKER_COUNT
+        node.vm.provision "ansible" do |ansible|
+          ansible.playbook = "./ansible/finalization.yaml"
+          ansible.limit = "ctrl"
+          ansible.extra_vars = {
+            ctrl_ip: CTRL_IP,
+            worker_count: WORKER_COUNT,
+            worker_ip_base: WORKER_IP_BASE
+          }
+        end
       end
     end
   end

--- a/ansible/finalization.yaml
+++ b/ansible/finalization.yaml
@@ -1,9 +1,5 @@
 ---
 
-# ansible-playbook -u vagrant -i 192.168.56.100, ./ansible/finalization.yaml
-# or if using WSL:
-# ansible-playbook -i ./ansible/inventory-wsl.ini ./ansible/finalization.yaml
-
 - hosts: all
   become: yes
   gather_facts: yes
@@ -18,6 +14,15 @@
     KUBECONFIG: /home/vagrant/.kube/config
 
   tasks:
+    - name: Wait for Kubernetes nodes to become ready
+      command: kubectl get nodes
+      register: nodes_status
+      until: "'Ready' in nodes_status.stdout"
+      retries: 30  # 30 retries * 15 seconds = 450s (7.5 minutes)
+      delay: 15
+      tags:
+        - always
+
     # Step 20: Install MetalLB
     - name: Download MetalLB native manifest
       get_url:


### PR DESCRIPTION
Adds the existing `ansible/finalization.yaml` playbook to the Vagrant controller provisioning so cluster finalization, verify this by simply running vagrant, the controller will automatically execute the finalization playbook during provisioning.