### PR TITLE
Rate Limit For Additional Use Case

### DIFF
--- a/deployment/templates/rateLimiting.yaml
+++ b/deployment/templates/rateLimiting.yaml
@@ -1,0 +1,46 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: {{ .Release.Name }}-local-ratelimit
+  namespace: {{ .Release.Namespace }}
+spec:
+  workloadSelector:
+    labels:
+      app.kubernetes.io/name: app-devops-app
+      app.kubernetes.io/instance: operation
+  configPatches:
+    - applyTo: HTTP_FILTER
+      match:
+        context: SIDECAR_INBOUND
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.filters.network.http_connection_manager"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: envoy.filters.http.local_ratelimit
+          typed_config:
+            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+            value:
+              stat_prefix: http_local_rate_limiter
+              token_bucket:
+                max_tokens: {{ .Values.istio.rateLimiting.maxTokens }}
+                tokens_per_fill: {{ .Values.istio.rateLimiting.tokensPerFill }}
+                fill_interval: {{ .Values.istio.rateLimiting.fillInterval }}
+              filter_enabled:
+                runtime_key: local_rate_limit_enabled
+                default_value:
+                  numerator: 100
+                  denominator: HUNDRED
+              filter_enforced:
+                runtime_key: local_rate_limit_enforced
+                default_value:
+                  numerator: 100
+                  denominator: HUNDRED
+              response_headers_to_add:
+                - append: false
+                  header:
+                    key: x-local-rate-limit
+                    value: 'true'

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -205,6 +205,12 @@ istio:
     image:
       repository: ghcr.io/doda25-team2/app
       tag: v1.3.1
+  rateLimiting:
+    enabled: true
+    maxTokens: 10
+    tokensPerFill: 10
+    fillInterval: 60s
+    perConnection: true
 
 # Prometheus 
 prometheus:


### PR DESCRIPTION
For the additional use case, rate limiting has been added in which this automatically throttles for users that send more then 10 requests per minute get blocked temporarily. This can be tested with the following commands after helm installation:

```
kubectl run curl-test --image=curlimages/curl -i --tty --rm --restart=Never -- sh
```

Inside paste this: 

```
for i in $(seq 1 15); do
  echo "$(curl -s -o /dev/null -w '%{http_code}' \
    -X POST http://app.default.svc.cluster.local/sms \
    -H 'Content-Type: application/json' \
    -d "{\"sms\": \"Test $i\"}")"
done
```

Based on this, the ouput should show the following:

```
200
200
200
 . 
 .
 .

429
429
429
429
```