### PR TITLE
added hostname of prerealse app to be configured in value.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ kubectl get nodes
 helm upgrade --install operation ./deployment
 
 # Add to /etc/hosts:
-# 192.168.56.95   sms-checker.local
+# 192.168.56.90   sms-checker.local
+# 192.168.56.90   sms-checker-prerelease.local
 # 192.168.56.95   grafana.local
 # 192.168.56.95   dashboard.local
 ```

--- a/deployment/templates/app-canary-virtualservice.yaml
+++ b/deployment/templates/app-canary-virtualservice.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.istio.enabled .Values.istio.canary.enabled .Values.istio.canary.host }}
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: {{ include "deployment.fullname" . }}-app-canary-vs
+spec:
+  hosts:
+    - {{ .Values.istio.canary.host | quote }}
+  gateways:
+    - {{ include "deployment.fullname" . }}-gateway
+  http:
+    - route:
+        - destination:
+            host: {{ .Values.services.app.name }}
+            port:
+              number: {{ .Values.services.app.port }}
+            subset: canary
+{{- end }}

--- a/deployment/templates/app-virtualservice.yaml
+++ b/deployment/templates/app-virtualservice.yaml
@@ -10,6 +10,18 @@ spec:
     - {{ include "deployment.fullname" . }}-gateway
   http:
     {{- if .Values.istio.canary.enabled }}
+    # Route users with x-user-id matching the regex to canary
+    - match:
+        - headers:
+            x-user-id:
+              regex: {{ .Values.istio.canary.headerRoutingRegex | quote }}
+      route:
+        - destination:
+            host: {{ .Values.services.app.name }}
+            port:
+              number: {{ .Values.services.app.port }}
+            subset: canary
+    # All other users go to stable
     - route:
         - destination:
             host: {{ .Values.services.app.name }}

--- a/deployment/templates/app-virtualservice.yaml
+++ b/deployment/templates/app-virtualservice.yaml
@@ -10,18 +10,6 @@ spec:
     - {{ include "deployment.fullname" . }}-gateway
   http:
     {{- if .Values.istio.canary.enabled }}
-    # Route users with x-user-id matching the regex to canary
-    - match:
-        - headers:
-            x-user-id:
-              regex: {{ .Values.istio.canary.headerRoutingRegex | quote }}
-      route:
-        - destination:
-            host: {{ .Values.services.app.name }}
-            port:
-              number: {{ .Values.services.app.port }}
-            subset: canary
-    # All other users go to stable
     - route:
         - destination:
             host: {{ .Values.services.app.name }}

--- a/deployment/templates/gateway.yaml
+++ b/deployment/templates/gateway.yaml
@@ -13,4 +13,7 @@ spec:
         protocol: HTTP
       hosts:
         - {{ .Values.istio.host | quote }}
+        {{- if and .Values.istio.canary.enabled .Values.istio.canary.host }}
+        - {{ .Values.istio.canary.host | quote }}
+        {{- end }}
 {{- end }}

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -212,6 +212,7 @@ istio:
     modelImage:
       repository: ghcr.io/doda25-team2/model-service
       tag: latest
+    host: "sms-checker-prerelease.local"
 
 # Prometheus 
 prometheus:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -100,12 +100,13 @@ To facilitate local development and testing, you can deploy the application on a
    helm install deployment ./deployment
    ```
 
-4. Add the following entry to your `/etc/hosts` file to map the application hostname to the loopback address:
+4. Add the following entry to your `/etc/hosts` file to map the application hostnames to the loopback address:
 
    ```
-   127.0.0.1 sms-checker.local
-   127.0.0.1 grafana.local
+   127.0.0.1 sms-checker.local sms-checker-prerelease.local grafana.local
    ```
+
+   > **Note:** In Minikube with `minikube tunnel`, all services share the same tunnel IP. In a production Vagrant cluster, `sms-checker.local` and `sms-checker-prerelease.local` use the Istio IngressGateway IP, while `grafana.local` uses the Nginx Ingress IP.
 
 5. Wait for the pods to be in the `Running` state:
 
@@ -134,14 +135,17 @@ The cluster must have Istio installed and an Istio IngressGateway configured. Se
    helm install deployment ./deployment
    ```
 
-2. Add the following entry to your DNS or `/etc/hosts` file to map the application hostname to the appropriate IP address of your Istio IngressGateway:
+2. Add the following entries to your DNS or `/etc/hosts` file to map the hostnames to the appropriate IP addresses:
 
    ```
-   <INGRESS_GATEWAY_IP> sms-checker.local
-   <INGRESS_GATEWAY_IP> grafana.local
+   <ISTIO_GATEWAY_IP> sms-checker.local sms-checker-prerelease.local
+   <NGINX_INGRESS_IP> grafana.local
    ```
 
-   Replace `<INGRESS_GATEWAY_IP>` with the actual IP address of your Istio IngressGateway.
+   - **Istio IngressGateway** (`192.168.56.90` by default, configured in [istio-operator.yaml](./../k8s/istio-operator.yaml)): Handles traffic for `sms-checker.local` and `sms-checker-prerelease.local` via Istio's Gateway and VirtualService resources.
+   - **Nginx Ingress Controller** (`192.168.56.95` by default): Handles traffic for `grafana.local` via Kubernetes Ingress resources.
+
+   > **Important:** `sms-checker-prerelease.local` provides direct access to the canary deployment and **must** resolve to the Istio IngressGateway IP, not the Nginx Ingress IP. Using the wrong IP will result in a 404 error.
 
 3. Wait for the pods to be in the `Running` state:
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -354,6 +354,7 @@ This realizes both a **canary deployment** and a **shadow launch**:
 
 ### Hostnames
 - `sms-checker.local` – primary entry point (configured as `.Values.istio.host`)
+- A separate configurable hostname (e.g., `sms-checker-prerelease.local` via `.Values.istio.canary.host`) is available for pre-release (canary) deployments.
 
 ### Ports
 - HTTP **80**, exposed via the Istio IngressGateway


### PR DESCRIPTION
This PR implements a dedicated hostname for the pre-release (canary) application, configurable via istio.canary.host in values.yaml. 
To test this change, add sms-checker-prerelease.local to your local /etc/hosts file. After deploying your system, verify
routing by curling http://sms-checker.local for the stable app and http://sms-checker-prerelease.local for the canary app.


